### PR TITLE
%status: Print empty line before backticks

### DIFF
--- a/extras.py
+++ b/extras.py
@@ -34,7 +34,9 @@ async def dump_cfg(price_fetcher):
     if block_height < 5 or not isinstance(block_hash, str): # 5 is largest error return value
         return '{}Could not access the Gridcoin client.'.format(e.ERROR)
 
-    return '''{}Bot is up. Configuration:```
+    return '''{}Bot is up. Configuration:
+
+```
 Withdraw fee: {} GRC
 Min. transfer limit: {} GRC
 Required confirmations per withdraw: {}


### PR DESCRIPTION
Workaround for formatting bug in Discord for iOS: https://trello.com/c/r83EsHrP


I discussed this bug in \#off-topic channel on the Gridcoin server. Screenshot of bug for reference (Discord 2.3.7):

![20180909_202216000_ios 2](https://user-images.githubusercontent.com/7941193/45286464-8e9f1e00-b4ab-11e8-8704-e6e208ffd5c1.png)


