### PR TITLE
new_user_restriction(): use datetime objects

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def is_owner():
 
 def new_user_restriction():
     def predicate(ctx):
-        if user_time(ctx.message.author.created_at)+24*60*60*g.NEW_USR_TIME > time():
+        if ctx.message.author.created_at + timedelta(days=g.NEW_USR_TIME) > datetime.utcnow():
             raise errors.TooNew()
         return True
     return commands.check(predicate)


### PR DESCRIPTION
Since [`author.created_at` is a `datetime` object](https://github.com/Rapptz/discord.py/blob/1863a1c6636f53592519320a173ec9573c090c0b/discord/utils.py#L121-L123) (not clearly documented by the API?), it can be added with a [`timedelta`](https://docs.python.org/3/library/datetime.html#datetime.timedelta) representing `NEW_USR_TIME` (in days), and then compared directly to [`utcnow()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow). Whereas the current approach requires converting `author.created_at` to a `float` for comparing with `time()`.

Note: I have not tested this, could this be tried on the test bot? In fact I'm not familiar with whether there's an easy way of creating a new dummy account or setting a given creation date to test this.
