### PR TITLE
user_stats(): use datetime's timestamp method

### DIFF
--- a/extras.py
+++ b/extras.py
@@ -206,13 +206,13 @@ def user_stats(user_obj, client, user_time):
     for member in client.get_all_members():
         if str(member.id) == user_obj.usrID:
             user = member
-            crtime = round(user_time(member.created_at))
+            crtime = round(member.created_at.timestamp())
             break
     if user is None:
         return '```{}```'.format(final)
     final += user_obj.get_stats().replace('`', '') + '\n'
     final += 'Created at: {} {}\n'.format(crtime, time.strftime("(%m Months %d Days %H Hours %M Minutes ago)", time.gmtime(time.time()-crtime)))
-    jtime = round(time.mktime(member.joined_at.timetuple()))
+    jtime = round(member.joined_at.timestamp())
     final += 'Joined at: {} {}'.format(jtime, time.strftime("(%m Months %d Days %H Hours %M Minutes ago)", time.gmtime(time.time()-jtime)))
     return '```{}```'.format(final)
 


### PR DESCRIPTION
Since [`member.created_at`](https://github.com/Rapptz/discord.py/blob/1863a1c6636f53592519320a173ec9573c090c0b/discord/utils.py#L121-L123) and [`member.joined_at`](https://discordpy.readthedocs.io/en/latest/api.html?highlight=joined_at#discord.Member.joined_at) are (UTC) `datetime` objects, they already have the [`timestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp) method to get a `time()`-like timestamp.

If this and #27 are merged, then `user_time()` will no longer be used by anything, except for its function reference being passed to `user_stats()`.

Again, this is untested. I don't think I can run %stat on my own user (Q: would letting users run it on themselves be a bad idea?).