### PR TITLE
%faq 8: escape backslashes

### DIFF
--- a/FAQ.py
+++ b/FAQ.py
@@ -160,7 +160,7 @@ description=r'''
 
 5. Configure the client according to the prompts or follow the [guide]({})
 
-6. After configuration, close the client completely and then open your configuration folder (Windows: C:\[User]\Appdata\Roaming\Gridcoinresearch\) (Linux: ~/.GridcoinResearch/)
+6. After configuration, close the client completely and then open your configuration folder (Windows: C:\\[User]\\Appdata\\Roaming\\Gridcoinresearch\\) (Linux: ~/.GridcoinResearch/)
 
 7. Delete everything in this folder apart from the wallet.dat, gridcoinresearch.conf and the walletbackups folder.
 


### PR DESCRIPTION
Note: this is separate from using a rawstring (which is so that Python doesn't mistake '\\' for escape sequences); this is needed for Discord's markdown formatting to preserve backslashes.