### PR TITLE
Bump required Python version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This bot aims to be a third part wallet service for the Gridcoin cryptocurrency 
 
 ## Requirements
 
-* Python 3.6
+* Python 3.7
 
 * A remote MYSQL database (such as [MariaDB](https://mariadb.com/))
 


### PR DESCRIPTION
Now using 3.7-only features (`await` in f-strings) as of
eb38c9a710c819a006d89de7ced28cf12c366343 (cf. https://github.com/delta1512/GRC-Wallet-Bot/pull/25#pullrequestreview-154455246)